### PR TITLE
Fix the link to installation instructions in tutorial

### DIFF
--- a/doc/tutorial/001-fundamentals.md
+++ b/doc/tutorial/001-fundamentals.md
@@ -8,7 +8,7 @@
  
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  2. Read the [before you start](000-before-you-start.md) tutorial
  3. Have access to a text editor or IDE for writing Go and JSON files and a terminal emulator or command prompt 
  (referred to as a terminal from now on)

--- a/doc/tutorial/002-configuration.md
+++ b/doc/tutorial/002-configuration.md
@@ -9,7 +9,7 @@
  
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  2. Read the [before you start](000-before-you-start.md) tutorial
  3. Either have completed [tutorial 1](001-fundamentals.md) or open a terminal and run
 

--- a/doc/tutorial/003-logging.md
+++ b/doc/tutorial/003-logging.md
@@ -8,7 +8,7 @@
  
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  2. Read the [before you start](000-before-you-start.md) tutorial
  3. Either have completed [tutorial 2](002-configuration.md) or open a terminal and run
 

--- a/doc/tutorial/004-data-capture.md
+++ b/doc/tutorial/004-data-capture.md
@@ -6,7 +6,7 @@
  
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  2. Read the [before you start](000-before-you-start.md) tutorial
  3. Either have completed [tutorial 3](003-logging.md) or open a terminal and run
 

--- a/doc/tutorial/005-validation.md
+++ b/doc/tutorial/005-validation.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  2. Read the [before you start](000-before-you-start.md) tutorial
  3. Either have completed [tutorial 4](004-data-capture.md) or open a terminal and run
 

--- a/doc/tutorial/006-database-read.md
+++ b/doc/tutorial/006-database-read.md
@@ -9,7 +9,7 @@
 
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  1. Read the [before you start](000-before-you-start.md) tutorial
  1. Either have completed [tutorial 5](005-validation.md) or open a terminal and run:
  

--- a/doc/tutorial/007-database-write.md
+++ b/doc/tutorial/007-database-write.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  1. Read the [before you start](000-before-you-start.md) tutorial
  1. Followed the [setting up a test database](006-database-read.md) section of [tutorial 6](006-database-read.md)
  1. Either have completed [tutorial 6](006-database-read.md) or open a terminal and run:

--- a/doc/tutorial/008-shared-validation.md
+++ b/doc/tutorial/008-shared-validation.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
- 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/doc/installation.md)
+ 1. Follow the Granitic [installation instructions](https://github.com/graniticio/granitic/blob/master/doc/installation.md)
  1. Read the [before you start](000-before-you-start.md) tutorial
  1. Followed the [setting up a test database](006-database-read.md) section of [tutorial 6](006-database-read.md)
  1. Either have completed [tutorial 7](007-database-write.md) or open a terminal and run:


### PR DESCRIPTION
Inside the Prerequisites header in the tutorial, the link to installation instructions is throwing an error 404 page not found. This PR fixes the link.