### PR TITLE
Fix misspells.

### DIFF
--- a/cmd/grnc-bind/bind.go
+++ b/cmd/grnc-bind/bind.go
@@ -29,7 +29,7 @@ Usage of grnc-bind:
 	-c string
 		A comma separated list of component definition files or directories containing component definition files (default "resource/components")
 	-m string
-		The path of a file where the merged component defintion file should be written to. Execution will halt after writing.
+		The path of a file where the merged component definition file should be written to. Execution will halt after writing.
 	-o string
 		Path to the Go source file that will be generated (default "bindings/bindings.go")
 	-l string

--- a/cmd/grnc-bind/binder/binder.go
+++ b/cmd/grnc-bind/binder/binder.go
@@ -886,7 +886,7 @@ func (b *Binder) validateTypeAvailable(v map[string]interface{}, name string) bo
 	t := v[typeField]
 
 	if t == nil {
-		b.Log.LogErrorf("Component %s does not have a 'type' defined in its component defintion (or any parent templates).\n", name)
+		b.Log.LogErrorf("Component %s does not have a 'type' defined in its component definition (or any parent templates).\n", name)
 		b.fail()
 		return false
 	}

--- a/cmd/grnc-bind/binder/env.go
+++ b/cmd/grnc-bind/binder/env.go
@@ -26,7 +26,7 @@ func LocateFacilityConfig(log logging.Logger) (string, error) {
 	var graniticPath string
 	var err error
 
-	notFound := fmt.Errorf("unable to find a Granitic installation - checked go.mod file, %s envrionment variable and standard checkout location under %s", graniticHomeEnvVar, goPathEnvVar)
+	notFound := fmt.Errorf("unable to find a Granitic installation - checked go.mod file, %s environment variable and standard checkout location under %s", graniticHomeEnvVar, goPathEnvVar)
 
 	log.LogDebugf("Looking for an installation of Granitic")
 

--- a/cmd/grnc-ctl/main.go
+++ b/cmd/grnc-ctl/main.go
@@ -19,7 +19,7 @@ to see a list of all commands, then
 
 	grnct-ctl help command-name
 
-to see usage and detailed help on an indiviudal command.
+to see usage and detailed help on an individual command.
 
 Usage of grnc-ctl:
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ Package config provides functionality for working with configuration files and c
 
 Grantic uses JSON files to store component definitions (declarations of, and relationships between, components to
 run in the IoC container) and configuration (variables used by IoC components that may vary between environments and settings
-for Grantic's built-in facilities). A defintion of the use and syntax of these files are outside of the scope of a GoDoc page,
+for Grantic's built-in facilities). A definition of the use and syntax of these files are outside of the scope of a GoDoc page,
 but are described in detail at https://granitic.io/ref/component-definition-files and https://granitic.io/ref/configuration-files
 
 This package defines functionality for loading a JSON file (from a filesystem or via HTTP) and merging multiple files into
@@ -287,7 +287,7 @@ func (ac *Accessor) configVal(path []string, jsonMap map[string]interface{}) int
 
 // SetField takes a target Go interface and uses the data a the supplied path to populated the named field on the
 // target. The target must be a pointer to a struct. The field must be a string, bool, int, float63, string[interface{}] map
-// or a slice of one of those types. An eror will be returned if the target field, is missing, not settable or incompatiable
+// or a slice of one of those types. An eror will be returned if the target field, is missing, not settable or incompatible
 // with the JSON value at the supplied path.
 func (ac *Accessor) SetField(fieldName string, path string, target interface{}) error {
 
@@ -409,7 +409,7 @@ func (ac *Accessor) arrayVal(a reflect.Value) (reflect.Value, error) {
 }
 
 // Populate sets the fields on the supplied target object using the JSON data
-// at the supplied path. This is acheived using Go's json.Marshal to convert the data
+// at the supplied path. This is achieved using Go's json.Marshal to convert the data
 // back into text JSON and then json.Unmarshal to unmarshal back into the target.
 func (ac *Accessor) Populate(path string, target interface{}) error {
 	exists := ac.PathExists(path)

--- a/config/config.go
+++ b/config/config.go
@@ -281,7 +281,7 @@ func (ac *Accessor) configVal(path []string, jsonMap map[string]interface{}) int
 		return result
 	}
 
-	remainPath := path[1:len(path)]
+	remainPath := path[1:]
 	return ac.configVal(remainPath, result.(map[string]interface{}))
 }
 

--- a/facility/logger/builder.go
+++ b/facility/logger/builder.go
@@ -5,7 +5,7 @@
 Package logger provides the FrameworkLogging and ApplicationLogging facilities which control logging from framework and application components.
 
 Full documentation for this facility can be found at https://granitic.io/ref/logging and GoDoc for the logging types that your application
-will interact with are detailled in the logging package.
+will interact with are detailed in the logging package.
 */
 package logger
 

--- a/granitic.go
+++ b/granitic.go
@@ -100,7 +100,7 @@ func StartGranitic(cs *ioc.ProtoComponents) {
 }
 
 // StartGraniticWithSettings starts the IoC container and populates it with the supplied list of prototype components and using the
-// provided intial settings. This function will run until the application is halted by an interrupt (ctrl+c) or
+// provided initial settings. This function will run until the application is halted by an interrupt (ctrl+c) or
 // a runtime control shutdown command.
 func StartGraniticWithSettings(cs *ioc.ProtoComponents, is *config.InitialSettings) {
 	i := new(initiator)

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -10,7 +10,7 @@ services can identify it.
 
 This package defines a type for storing an instance ID and an interface to be implemented
 by any component that needs to be aware of the ID of the current instance. An instance ID is specified when starting
-Granitic via a command line argument or an InitialSettings struct. See the documentation for the granitic pacakge for
+Granitic via a command line argument or an InitialSettings struct. See the documentation for the granitic package for
 more detail.
 
 This package also defines the data structure for the implicit System facility (which cannot be disabled, but can be configured).

--- a/ioc/component.go
+++ b/ioc/component.go
@@ -91,7 +91,7 @@ Binding
 
 Unlike JVM/CLR languages, Go has no runtime 'instance-for-type-name' mechanism for creating instances of a struct. As
 a result, unlike JVM/CLR IoC containers you may have used, the container does not instantiate the actual instances
-of the Go structs behind application components. Instead a 'binding' proces is used - refer to the pacakage documentation
+of the Go structs behind application components. Instead a 'binding' process is used - refer to the package documentation
 for the grnc-bind tool for more information.
 
 Container lifecycle
@@ -235,7 +235,7 @@ type ProtoComponent struct {
 	// A map of fields on the component instance and the config-path that will contain the configuration that shoud be inject into the field.
 	ConfigPromises map[string]string
 
-	// A map of default values for fields if a config promise is not fulfiled
+	// A map of default values for fields if a config promise is not fulfilled
 	DefaultValues map[string]string
 }
 
@@ -261,7 +261,7 @@ func (pc *ProtoComponent) AddConfigPromise(fieldName, configPath string) {
 	pc.ConfigPromises[fieldName] = configPath
 }
 
-// AddDefaultValue records an untyped default value to use if a config promise is not fulfiled
+// AddDefaultValue records an untyped default value to use if a config promise is not fulfilled
 func (pc *ProtoComponent) AddDefaultValue(fieldName, value string) {
 
 	if pc.DefaultValues == nil {

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -19,7 +19,7 @@ Any component in your application will have a Logger injected into it if the und
 
 	Log logging.Logger
 
-The Logger is injected during the 'decoration' phase of container startup ( implements package documentation for the ioc pacakge). This
+The Logger is injected during the 'decoration' phase of container startup ( implements package documentation for the ioc package). This
 means the Logger is safe to use in any method in your component.
 
 Log levels
@@ -209,7 +209,7 @@ type Logger interface {
 	//LogAtLevelfCtx log at the specified level
 	LogAtLevelf(level LogLevel, levelLabel string, format string, a ...interface{})
 
-	//IsLevelEnabled returns true if a message at the supplied level would acutally be logged. Useful to check
+	//IsLevelEnabled returns true if a message at the supplied level would actually be logged. Useful to check
 	//if the construction of a message would be expensive or slow.
 	IsLevelEnabled(level LogLevel) bool
 }

--- a/rdbms/manager.go
+++ b/rdbms/manager.go
@@ -157,7 +157,7 @@ and end your method with:
 	db.CommitTransaction()
 
 
-The deferred Rollback call will do nothing if the transaction has previously been commited.
+The deferred Rollback call will do nothing if the transaction has previously been committed.
 
 
 Direct access to Go DB methods

--- a/schedule/parse.go
+++ b/schedule/parse.go
@@ -52,7 +52,7 @@ func parseNaturalToDuration(interval string) (time.Duration, error) {
 }
 
 func parseValueUnit(value, unit string) (int64, time.Duration, error) {
-	//Make such the first token is a postive integer
+	//Make such the first token is a positive integer
 	frequencyValue, okay := validValue(value)
 
 	if !okay {

--- a/types/params.go
+++ b/types/params.go
@@ -157,7 +157,7 @@ type FieldAssociatedError interface {
 	RecordField(string)
 }
 
-// ParamValueInjector takes a series of key/value (string/string) paramters and tries to inject them into the fields
+// ParamValueInjector takes a series of key/value (string/string) parameters and tries to inject them into the fields
 // on a target struct
 type ParamValueInjector struct {
 }

--- a/validate/string.go
+++ b/validate/string.go
@@ -328,7 +328,7 @@ func (sv *StringValidationRule) Break() *StringValidationRule {
 
 }
 
-// Length adds a check to see if the string has a lenght between the supplied min and max values.
+// Length adds a check to see if the string has a length between the supplied min and max values.
 func (sv *StringValidationRule) Length(min, max int, code ...string) *StringValidationRule {
 
 	sv.minLen = min

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -247,7 +247,7 @@ type ValidationRule interface {
 	// Check the subject provided in the supplied context and return any found errors.
 	Validate(vc *ValidationContext) (result *ValidationResult, unexpected error)
 
-	// Tell the coordinating object that no other rules should be procesed if errors are found by this rule.
+	// Tell the coordinating object that no other rules should be processed if errors are found by this rule.
 	StopAllOnFail() bool
 
 	// Summarise all of the unique error codes referenced by checks in this rule.

--- a/ws/error.go
+++ b/ws/error.go
@@ -69,7 +69,7 @@ type ServiceErrorConsumer interface {
 
 // ServiceErrors is a structure that records each of the errors found during the processing of a request.
 type ServiceErrors struct {
-	// All services found, in the order in which they occured.
+	// All services found, in the order in which they occurred.
 	Errors []CategorisedError
 
 	// An externally computed HTTP status code that reflects the mix of errors in this structure.
@@ -110,7 +110,7 @@ func (se *ServiceErrors) AddPredefinedError(code string, field ...string) error 
 	}
 
 	if e == nil {
-		message := fmt.Sprintf("An error occured with code %s, but no error message is available", code)
+		message := fmt.Sprintf("An error occurred with code %s, but no error message is available", code)
 		e = NewCategorisedError(Unexpected, code, message)
 
 	}

--- a/ws/handler/handler.go
+++ b/ws/handler/handler.go
@@ -59,7 +59,7 @@ const processPayloadFunc = "ProcessPayload"
 // WsRequestProcessor specifies the minimum required of a component to be considered a 'logic' component suitable for
 // use by a WsHandler.
 type WsRequestProcessor interface {
-	// Process performs the actual 'work' of a web service request. The reponse parameter will be modified according to
+	// Process performs the actual 'work' of a web service request. The response parameter will be modified according to
 	// the output or errors that the web service caller should see.
 	Process(ctx context.Context, request *ws.Request, response *ws.Response)
 }

--- a/ws/handler/handler.go
+++ b/ws/handler/handler.go
@@ -717,7 +717,7 @@ func (wh *WsHandler) checkLogicComponent() error {
 
 func (wh *WsHandler) validateProcessPayload() error {
 
-	err := fmt.Errorf("Logic compoonent must either implement WsRequestProcessor or have method %s(ctx context.Context, request *ws.Request, response *ws.Response, payload *YourStruct)", processPayloadFunc)
+	err := fmt.Errorf("Logic component must either implement WsRequestProcessor or have method %s(ctx context.Context, request *ws.Request, response *ws.Response, payload *YourStruct)", processPayloadFunc)
 
 	if wh.Logic == nil {
 		return err

--- a/ws/marshal.go
+++ b/ws/marshal.go
@@ -45,7 +45,7 @@ type MarshallingResponseWriter struct {
 	// Component able to serialize the data to the HTTP output stream.
 	MarshalingWriter MarshalingWriter
 
-	// Whether or not the unique ID assigned to the request should be written as a reponse header
+	// Whether or not the unique ID assigned to the request should be written as a response header
 	IncludeRequestID bool
 
 	// The header key used if the request ID should be written as a response header


### PR DESCRIPTION
**Changes**
- Fixed misspells detected by [Go Report Card](https://goreportcard.com/report/github.com/graniticio/granitic#misspell)
- Run `gofmt -s` in config.go.