### PR TITLE
Add stdout accesslog writing #47

### DIFF
--- a/doc/ref/fac-http-server.md
+++ b/doc/ref/fac-http-server.md
@@ -183,7 +183,7 @@ configuration.
 
 This will create (or append) a UTF-8 encoded file called `access.log` in the same directory that you started your application (e.g. your
 application's working directory). You can change this specifying a full or relative path to a file with
-`HTTPServer.AccessLog.LogPath`. Your application must have filesystem permission to create and edit the file at that path.  
+`HTTPServer.AccessLog.LogPath`. Your application must have filesystem permission to create and edit the file at that path. You can also choose to be written stdout instead of a file to fill in "stdout".  
 
 The format and information recorded for each request is highly customisable and is described in detail below.
 

--- a/facility/httpserver/accesslog.go
+++ b/facility/httpserver/accesslog.go
@@ -8,15 +8,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/graniticio/granitic/v2/httpendpoint"
-	"github.com/graniticio/granitic/v2/ioc"
-	"github.com/graniticio/granitic/v2/logging"
 	"net/http"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/graniticio/granitic/v2/httpendpoint"
+	"github.com/graniticio/granitic/v2/ioc"
+	"github.com/graniticio/granitic/v2/logging"
 )
 
 const percent = "%"
@@ -243,8 +244,10 @@ func (alw *AccessLogWriter) openFile() (closableStringWriter, error) {
 		return nil, errors.New("HTTP server access log is enabled, but no path to a log file specified")
 	}
 
+	if logPath == "stdout" {
+		return os.Stdout, nil
+	}
 	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-
 	if err != nil {
 		return nil, err
 	}

--- a/facility/httpserver/accesslog_test.go
+++ b/facility/httpserver/accesslog_test.go
@@ -14,6 +14,37 @@ import (
 	"time"
 )
 
+func TestAccessLogWriterWithStdout(t *testing.T) {
+
+	alw := new(AccessLogWriter)
+
+	alw.LogLinePreset = "combined"
+	alw.LineBufferSize = 1
+
+	alw.LogPath = "stdout"
+
+	if err := alw.StartComponent(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	req := new(http.Request)
+
+	end := time.Now()
+
+	start := end.Add(time.Second * -2)
+
+	rw := new(httpendpoint.HTTPResponseWriter)
+	rw.DataSent = true
+	rw.Status = 200
+
+	alw.LogRequest(context.Background(), req, rw, &start, &end)
+
+	alw.PrepareToStop()
+
+	if ready, _ := alw.ReadyToStop(); ready {
+		alw.Stop()
+	}
+}
 func TestAccessLogWriterWithActualFile(t *testing.T) {
 
 	alw := new(AccessLogWriter)


### PR DESCRIPTION
Fixes #47 

The value of returning `AccessLogWriter.openFile` is the `os.File` pointer which is specified by `logPath`, So if `logPath` is “stdout”, it can be written in stdout to specify `os.Stdout`