### PR TITLE
Implement Accessible to check if context filter is injected for JSONLogFormatter

### DIFF
--- a/granitic.go
+++ b/granitic.go
@@ -69,22 +69,23 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/gob"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
 	"github.com/graniticio/granitic/v2/config"
 	"github.com/graniticio/granitic/v2/facility"
 	"github.com/graniticio/granitic/v2/instance"
 	"github.com/graniticio/granitic/v2/ioc"
 	"github.com/graniticio/granitic/v2/logging"
 	"github.com/graniticio/granitic/v2/uuid"
-	"os"
-	"os/signal"
-	"runtime"
-	"syscall"
-	"time"
 )
 
 const (
 	//Version is the semantic version number for this version of Granitic
-	Version                            = "2.2.1"
+	Version                            = "2.2.2"
 	initiatorComponentName      string = instance.FrameworkPrefix + "Init"
 	systemPath                         = "System"
 	configAccessorComponentName string = instance.FrameworkPrefix + "Accessor"

--- a/logging/structured.go
+++ b/logging/structured.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/graniticio/granitic/v2/instance"
-	"github.com/graniticio/granitic/v2/types"
 	"strings"
 	"time"
+
+	"github.com/graniticio/granitic/v2/instance"
+	"github.com/graniticio/granitic/v2/types"
 )
 
 // A JSONLogFormatter is a component able to take a message to be written to a log file and format it as JSON document
@@ -30,8 +31,8 @@ func (jlf *JSONLogFormatter) Format(ctx context.Context, levelLabel, loggerName,
 	return cfg.Prefix + string(entry) + cfg.Suffix
 }
 
-// StartComponent checks that a context filter has been injected (if the field configuration needs on)
-func (jlf *JSONLogFormatter) StartComponent() error {
+// AllowAccess checks that a context filter has been injected (if the field configuration needs on)
+func (jlf *JSONLogFormatter) AllowAccess() error {
 
 	mb := jlf.MapBuilder
 

--- a/logging/structured_test.go
+++ b/logging/structured_test.go
@@ -172,7 +172,7 @@ func TestContextVal(t *testing.T) {
 
 	jf.SetContextFilter(cf)
 
-	if jf.StartComponent() != nil {
+	if jf.AllowAccess() != nil {
 		t.Fatalf("Failed to detect supplied context filter")
 	}
 
@@ -324,7 +324,7 @@ func TestMessageFromStackTrace(t *testing.T) {
 
 	jf.SetContextFilter(cf)
 
-	if jf.StartComponent() != nil {
+	if jf.AllowAccess() != nil {
 		t.Fatalf("Failed to detect supplied context filter")
 	}
 
@@ -370,7 +370,7 @@ func TestStackTraceNoMessage(t *testing.T) {
 
 	jf.SetContextFilter(cf)
 
-	if jf.StartComponent() != nil {
+	if jf.AllowAccess() != nil {
 		t.Fatalf("Failed to detect supplied context filter")
 	}
 

--- a/logging/structured_test.go
+++ b/logging/structured_test.go
@@ -5,9 +5,10 @@ package logging
 
 import (
 	"context"
-	"github.com/graniticio/granitic/v2/instance"
 	"strings"
 	"testing"
+
+	"github.com/graniticio/granitic/v2/instance"
 )
 
 func TestUnsupportedContent(t *testing.T) {
@@ -141,7 +142,7 @@ func TestMissingContextFilter(t *testing.T) {
 	jf.Config = &cfg
 	jf.MapBuilder = mb
 
-	if jf.StartComponent() == nil {
+	if jf.AllowAccess() == nil {
 		t.Fatalf("Failed to detect missing context filter")
 	}
 


### PR DESCRIPTION
## Summary

`JSONLogFormatter` relies on context filter being set by `ComponentLoggerManager` in `StartComponent` life cycle method. Currently `JSONLogFormatter` tries to retrive the value in `StartComponent` life cycle method. Since the execution of componet lifecycle methods are non deterministic, if `JSONLogFormatter`'s `StartComponent` is called before `ComponentLoggerManager` the application fails to start.

In order to ensure that the `ComponentLoggerManager` `StartComponent` is always called, the logic in `JSONLogFormatter` `StartComponent` is moved to `AllowAccess` Life cycle method which ensures every components `StartComponent` have been invoked.


Fixes https://github.com/graniticio/granitic/issues/61